### PR TITLE
Add drag actions for devices that report touch moves

### DIFF
--- a/PythonScreenStackManager/constants.py
+++ b/PythonScreenStackManager/constants.py
@@ -119,8 +119,15 @@ class FEATURES:
 
     FEATURE_PRESS_RELEASE = "FEATURE_PRESS_RELEASE"
     """Feature to indicate the device is interactive and can report the coordinates of a press and the coordinates of a release
-    
+
     This feature allows elements to use the ``hold_release_action``.
+    """
+
+    FEATURE_TOUCH_MOVE = "FEATURE_TOUCH_MOVE"
+    """Feature to indicate the device also reports the coordinates of a touch moving while it is pressed down.
+
+    Requires ``FEATURE_PRESS_RELEASE``, as the move events are reported in between a press and a release.
+    This feature allows elements to use the ``drag_action``.
     """
 
     @classmethod
@@ -168,6 +175,12 @@ TOUCH_PRESS = "TOUCH-PRESSED"
 
 TOUCH_RELEASE = "TOUCH-RELEASED"
 "Indicates the touch event is the object leaving the screen"
+
+TOUCH_MOVE = "TOUCH-MOVED"
+"""Indicates the touch event is the object moving while it stays pressed against the screen.
+
+Only reported by devices with ``FEATURE_TOUCH_MOVE``, in between a press and a release. Dispatches to the element's ``drag_action``.
+"""
 
 TOUCH_TAP = "TOUCH-TAP"
 "Indicates a short touch event, for devices that do not support reporting both press and release events"

--- a/PythonScreenStackManager/devices/__init__.py
+++ b/PythonScreenStackManager/devices/__init__.py
@@ -436,6 +436,8 @@ class PSSMdevice(ABC):
         ----------
         touch_queue : asyncio.Queue, optional
             asyncio queue where touch events are put into. PSSM waits for items in this queue, by default None (for non interactive devices)
+            Devices with ``FEATURE_PRESS_RELEASE`` report ``TOUCH_PRESS`` and ``TOUCH_RELEASE`` events, and devices with ``FEATURE_TOUCH_MOVE`` also report the ``TOUCH_MOVE`` events in between those two.
+            Devices without either feature report ``TOUCH_TAP`` and ``TOUCH_LONG`` events.
         grabInput : bool, optional
             Prevent any other software from listening to touched, by default False. Not implemented for every device.
         """

--- a/PythonScreenStackManager/devices/windowed.py
+++ b/PythonScreenStackManager/devices/windowed.py
@@ -29,6 +29,9 @@ from ..pssm.decorators import trigger_condition
 
 _LOGGER = logging.getLogger(__name__)
 
+MOTION_MIN_DISTANCE = 5
+"Minimum distance in pixels the mouse has to move before a new move event is passed on to PSSM"
+
 t = tk
 
 if tk._default_root:
@@ -140,6 +143,7 @@ class Device(PSSMdevice):
 
         if features == None:
             features = DeviceFeatures(**{FEATURES.FEATURE_INTERACTIVE: interactive, FEATURES.FEATURE_PRESS_RELEASE: interactive,
+                                        FEATURES.FEATURE_TOUCH_MOVE: interactive,
                                         FEATURES.FEATURE_BACKLIGHT: backlight_features, FEATURES.FEATURE_NETWORK: network_features})
 
         super().__init__(features, 
@@ -375,6 +379,8 @@ class Device(PSSMdevice):
             self._eventQueue = eventQueue
             self.canvas.bind("<Button-1>", self.canvas_event)
             self.canvas.bind("<ButtonRelease-1>", self.canvas_event)
+            if self.has_feature(FEATURES.FEATURE_TOUCH_MOVE):
+                self.canvas.bind("<B1-Motion>", self.canvas_event)
 
         if self.has_feature(FEATURES.FEATURE_BACKLIGHT):
             self.backlight : "Backlight"
@@ -387,9 +393,21 @@ class Device(PSSMdevice):
         _LOGGER.verbose(f"Got event {event} from tkinter, passing to PSSM")
         if event.type == tk.EventType.ButtonPress:
             touch_type = const.TOUCH_PRESS
+            self._lastMotionEvent = (event.x, event.y)
         elif event.type == tk.EventType.ButtonRelease:
             touch_type = const.TOUCH_RELEASE
-        
+        elif event.type == tk.EventType.Motion:
+            ##Tkinter reports a motion event for every pixel the mouse moves, which would flood the queue.
+            ##Mice are also a lot more precise than fingers, so small movements are not reported.
+            last_x, last_y = getattr(self, "_lastMotionEvent", (event.x, event.y))
+            if abs(event.x - last_x) < MOTION_MIN_DISTANCE and abs(event.y - last_y) < MOTION_MIN_DISTANCE:
+                return
+            self._lastMotionEvent = (event.x, event.y)
+            touch_type = const.TOUCH_MOVE
+        else:
+            _LOGGER.verbose(f"Not passing on event of type {event.type} to PSSM")
+            return
+
         touch_event = TouchEvent(event.x, event.y, touch_type)
         self.eventQueue.put_nowait(touch_event)
         _LOGGER.debug(f"Send touch event {touch_event}")   

--- a/PythonScreenStackManager/elements/baseelements.py
+++ b/PythonScreenStackManager/elements/baseelements.py
@@ -92,6 +92,11 @@ class Element(ABC):
     tap_action : InteractionFunctionType, optional
         An action to call when interacting (tapping) this element, by default None
         See the docstring for the property on usage
+    drag_action : InteractionFunctionType, optional
+        An action to call when dragging over this element, by default None
+        Only usable on devices with ``FEATURE_TOUCH_MOVE``. See the docstring for the property on usage
+    drag_as_tap : bool, optional
+        Call this element's ``tap_action`` when it is dragged over, if no ``drag_action`` is set, by default False
     background_color : Optional[ColorType], optional
         color of the element's background, by default None
     isInverted : bool, optional
@@ -199,6 +204,8 @@ class Element(ABC):
                 tap_action: InteractionFunctionType = None,
                 hold_action: InteractionFunctionType = None,
                 hold_release_action: InteractionFunctionType = None,
+                drag_action: InteractionFunctionType = None,
+                drag_as_tap: bool = False,
                 background_color: Optional[ColorType] = "style::background_color",
                 inverted: bool = "style::inverted", 
                 show_feedback: bool = "style::show_feedback",
@@ -249,6 +256,12 @@ class Element(ABC):
         self.hold_release_action_data = {}
         self.hold_release_action_map = {}
         self.hold_release_action = hold_release_action
+
+        self._drag_action = None
+        self.drag_action_data = {}
+        self.drag_action_map = {}
+        self.drag_action = drag_action
+        self.drag_as_tap = drag_as_tap
 
         # self._isInverted = self.get_style_value(inverted)
         self.inverted = inverted
@@ -547,7 +560,31 @@ class Element(ABC):
         This function is only available on devices with the HOLD_RELEASE feature. Set to None to have nothing called.
         If set to a dict, the values for hold_release_action_data and hold_release_action_map will be overwritten if the respective key is present.
         """
-        return self._hold_release_action 
+        return self._hold_release_action
+
+    @elementaction
+    def drag_action(self) -> InteractionFunctionType:
+        """The function called when a touch is dragged over the element.
+
+        The element that is pressed down on captures the touch, i.e. it keeps receiving the drag events until the touch is released, even when it moves outside of the element's area.
+        Elements with a drag action do not receive a ``hold_action`` when the touch moves, and get a final drag event instead of a ``tap_action`` when it is released.
+        This function is only available on devices with the ``FEATURE_TOUCH_MOVE`` feature. Set to None to have nothing called.
+        If set to a dict, the values for drag_action_data and drag_action_map will be overwritten if the respective key is present.
+        """
+        return self._drag_action
+
+    @property
+    def drag_as_tap(self) -> bool:
+        """If True, dragging over the element calls its ``tap_action``, if no ``drag_action`` is set.
+
+        Convenience option for elements that should simply keep responding while a touch moves over them.
+        The interaction is still passed to the function as a drag, so functions can tell the two apart if they need to.
+        """
+        return self.__drag_as_tap
+
+    @drag_as_tap.setter
+    def drag_as_tap(self, value: bool):
+        self.__drag_as_tap = bool(value)
 
     @property
     def parentBackground(self) -> Union[ColorType,None]:
@@ -1258,12 +1295,36 @@ class Element(ABC):
         func_attr = f"_{attribute}"
         setattr(self,func_attr, func)
 
-    def _get_action(self, touch_type: Literal["tap", "hold","hold_release"]) -> Optional[tuple[InteractionFunctionType, dict]]:        
-        
+    def _get_action(self, touch_type: Literal["tap", "hold","hold_release","drag"]) -> Optional[tuple[InteractionFunctionType, dict]]:
+
+        if touch_type == "drag" and self.drag_as_tap and self.drag_action is None:
+            ##Elements can opt into having drags call their tap_action, instead of requiring a seperate function.
+            touch_type = "tap"
+
         if (func := getattr(self, f"{touch_type}_action", None)) != None:
             kwargs = getattr(self, f"{touch_type}_action_kwargs",{})
             if func:
                 return (func, kwargs)
+
+    def _get_drag_target(self, x: int, y: int) -> Optional["Element"]:
+        """Returns the element that captures a touch pressed down on the coordinates (x,y), if any.
+
+        Returns ``self`` if this element handles drags, and ``None`` otherwise. Layouts return the appropriate child element.
+        The returned element receives every drag event until the touch is released, regardless of where the touch moves to.
+
+        Parameters
+        ----------
+        x : int
+            x coordinate of the press
+        y : int
+            y coordinate of the press
+
+        Returns
+        -------
+        Optional[Element]
+            The element to capture the touch, or None if nothing handles drags there
+        """
+        return self if self._get_action("drag") else None
 
     @abstractmethod
     def generator(self, area : PSSMarea=None, skipNonLayoutGen : bool =False) -> Image.Image:
@@ -2184,6 +2245,37 @@ class Layout(Element):
         """Finds the element on which the user clicked and returns a list of the found onTap functions
         """
         return await self._dispatch_click_LINEAR(interaction)
+
+    def _get_element_at(self, x: int, y: int) -> Optional[Element]:
+        """Returns the element in this layout that is at the coordinates (x,y), if any.
+
+        Parameters
+        ----------
+        x : int
+            x coordinate to look at
+        y : int
+            y coordinate to look at
+
+        Returns
+        -------
+        Optional[Element]
+            The element at those coordinates, or None if the layout has no element there
+        """
+        try:
+            for i in range(len(self.areaMatrix)):
+                for j in range(len(self.areaMatrix[i])):
+                    if tools.coords_in_area(x, y, self.areaMatrix[i][j]):
+                        return self.layout[i][j+1][0]
+        except FuncExceptions as exce:
+            _LOGGER.warning(f"{self}: Cannot iterate fully to find the element at {(x,y)}: {exce}", exc_info=exce)
+        return None
+
+    def _get_drag_target(self, x: int, y: int) -> Optional[Element]:
+        "Passes on the request to the element at these coordinates, and falls back to the layout itself."
+        elt = self._get_element_at(x, y)
+        if elt is not None and (target := elt._get_drag_target(x, y)) is not None:
+            return target
+        return super()._get_drag_target(x, y)
 
     async def _dispatch_click_LINEAR(self, interaction: InteractEvent):
         """
@@ -5739,9 +5831,12 @@ class _BaseSlider(Element):
     value_type : int, float
         The type to return when calling Slider.Value, handy when requiring integers. Defaults to float
     interactive : bool, optional
-        whether the slider updates its position when it is clicked, by default True
+        whether the slider updates its position when it is clicked, or dragged on devices supporting it, by default True
     tap_action : Callable[elt, coords], optional
         function to call when tapping the slider, by default None
+    drag_action : Callable[elt, coords], optional
+        function to call when dragging the slider, by default None
+        Requires a device with ``FEATURE_TOUCH_MOVE``
     """
 
     @classproperty
@@ -5882,6 +5977,18 @@ class _BaseSlider(Element):
         return self.__tap_action
 
     @elementaction
+    def drag_action(self) -> InteractionFunctionType:
+        """Slider ``drag_action`` that allows dragging the slider to a new position.
+
+        Works like the ``tap_action``: it first updates the slider position, and then calls the set drag_action.
+        Only has an effect on devices with the ``FEATURE_TOUCH_MOVE`` feature.
+        Use Slider._drag_action to access the actual function after setting.
+        """
+        if not self.interactive and self._drag_action is None:
+            return None
+        return self.__drag_action
+
+    @elementaction
     def on_position_set(self) -> Callable[["_BaseSlider",Union[float,int]],Any]:
         """Action that is called whenever the slider's position changes.
         Passes the element and the new position."""
@@ -5897,6 +6004,15 @@ class _BaseSlider(Element):
         if self._tap_action == None:
             return
         await tools.wrap_to_coroutine(self._tap_action,elt,coords, **kwargs)
+
+    async def __drag_action(self, elt, coords, **kwargs):
+        if self.interactive:
+            await self._slider_interact(elt,coords)
+            kwargs.update(self.drag_action_kwargs)
+
+        if self._drag_action == None:
+            return
+        await tools.wrap_to_coroutine(self._drag_action,elt,coords, **kwargs)
 
     async def feedback_function(self):
         

--- a/PythonScreenStackManager/pssm/screen.py
+++ b/PythonScreenStackManager/pssm/screen.py
@@ -1568,43 +1568,122 @@ class PSSMScreen:
             await asyncio.sleep(0)
             self._interactEvent.set()
 
+    def _get_drag_element(self, x : int, y : int) -> Optional["elements.Element"]:
+        """Returns the element that captures the drag events of a touch pressed down on (x,y), if any.
+
+        Mirrors the way ``_async_interact_handler`` looks for the element to dispatch a click to, and asks it (and its children, for layouts) for the element handling drags.
+
+        Parameters
+        ----------
+        x : int
+            x coordinate of the press
+        y : int
+            y coordinate of the press
+
+        Returns
+        -------
+        Optional[elements.Element]
+            The element to send the drag events to, or None if nothing handles drags there
+        """
+        if self.popupsOnTop:
+            popup = self.popupsOnTop[-1]
+            if popup.area is not None and tools.coords_in_area(x, y, popup.area):
+                return popup._get_drag_target(x, y)
+            return None
+
+        n = len(self.stack)
+        for i in range(n):
+            elt = self.stack[n-1-i]     # We go through the stack in descending order
+            if elt.area is None:
+                continue
+
+            if tools.coords_in_area(x, y, elt.area) and hasattr(elt,"tap_action"):
+                return elt._get_drag_target(x, y)
+        return None
+
     async def __async_touch_handler(self, queue: asyncio.Queue):
-            "Handles devices that can report on touch and release"
+            """Handles devices that can report on touch and release
+
+            Devices with the ``FEATURE_TOUCH_MOVE`` feature can also report the touch moving in between the press and the release.
+            The element that is pressed down on captures those events, and keeps receiving them until the touch is released, even when it moves outside of that element.
+            Dragging suppresses the ``hold_action`` and the ``tap_action`` of that interaction, so an element only gets drag events (and, if it was already held down long enough, a ``hold_release_action``).
+            """
 
             ##Replace this with a setting for the device.
             debounce_time = self.__touchDebounceTime
             min_hold_time = self.__minimumHoldTime
-            while self.printing:
-                event: tools.TouchEvent = await queue.get()
+            handle_drags = self.device.has_feature(FEATURES.FEATURE_TOUCH_MOVE)
+            loop = asyncio.get_event_loop()
 
-                if event.touch_type != const.TOUCH_PRESS:
+            while self.printing:
+                press: tools.TouchEvent = await queue.get()
+
+                if press.touch_type != const.TOUCH_PRESS:
                     continue
-                
-                release_task = asyncio.create_task(coro=queue.get())    ##This has to be a task, otherwise the result is removed from the queue somewhere else
-                done, _ = await asyncio.wait([release_task], timeout=debounce_time)
-                if done:
-                    ##Should not have received a second touch before the debounce time elapsed
-                    _LOGGER.debug("Touch Debounced")
-                    continue
+
+                press_time = loop.time()
+                drag_element = self._get_drag_element(press.x, press.y) if handle_drags else None
+                dragging = False
+                hold_dispatched = False
+                event_task = None
 
                 self._interactEvent.clear()
-                done, _ = await asyncio.wait([release_task], timeout=min_hold_time)
 
-                if done:
-                    event = release_task.result()
-                    asyncio.create_task(self._async_interact_handler(event.x,event.y, "tap"))
-                else:
-                    asyncio.create_task(self._async_interact_handler(event.x,event.y, "hold"))
-                    event = await release_task
-                    asyncio.create_task(self._async_interact_handler(event.x,event.y, "hold_release"))
-                    ##Will maybe make a NamedTuple to pass instead of coords and action seperately?
-                _LOGGER.debug(f"Click at {(event.x,event.y)} dispatched")
-                
+                while True:
+                    ##Waiting out the hold time, unless the touch is already being dragged or has already been held.
+                    ##asyncio.wait (as opposed to wait_for) leaves the pending task alive when it times out, so no event is dropped.
+                    if dragging or hold_dispatched:
+                        timeout = None
+                    else:
+                        timeout = max(0, min_hold_time - (loop.time() - press_time))
+
+                    if event_task is None:
+                        event_task = asyncio.create_task(coro=queue.get())  ##This has to be a task, otherwise the result is removed from the queue somewhere else
+
+                    done, _ = await asyncio.wait([event_task], timeout=timeout)
+                    if not done:
+                        ##The touch was not released before the hold time elapsed
+                        asyncio.create_task(self._async_interact_handler(press.x,press.y, "hold"))
+                        hold_dispatched = True
+                        continue
+
+                    event : tools.TouchEvent = event_task.result()
+                    event_task = None
+
+                    if event.touch_type == const.TOUCH_MOVE:
+                        if drag_element is not None:
+                            ##Moving cancels the hold, since the touch is now considered to be dragging the element
+                            dragging = True
+                            asyncio.create_task(self._async_interact_handler(event.x,event.y, "drag", drag_element))
+                        continue
+
+                    if event.touch_type != const.TOUCH_RELEASE:
+                        ##Anything else (i.e. a second press) is not part of this interaction
+                        continue
+
+                    if dragging:
+                        ##Finalising the drag on the coordinates the touch was released on
+                        asyncio.create_task(self._async_interact_handler(event.x,event.y, "drag", drag_element))
+                        if hold_dispatched:
+                            asyncio.create_task(self._async_interact_handler(event.x,event.y, "hold_release"))
+                    elif hold_dispatched:
+                        asyncio.create_task(self._async_interact_handler(event.x,event.y, "hold_release"))
+                        ##Will maybe make a NamedTuple to pass instead of coords and action seperately?
+                    elif loop.time() - press_time < debounce_time:
+                        ##Should not have been released before the debounce time elapsed
+                        _LOGGER.debug("Touch Debounced")
+                        break
+                    else:
+                        asyncio.create_task(self._async_interact_handler(event.x,event.y, "tap"))
+
+                    _LOGGER.debug(f"Click at {(event.x,event.y)} dispatched")
+                    break
+
                 self._interactEvent.set()
 
             _LOGGER.warning("Touch listener has stopped")
 
-    async def _async_interact_handler(self, x : int, y : int, action: TouchActionType):
+    async def _async_interact_handler(self, x : int, y : int, action: TouchActionType, element : Optional["elements.Element"] = None):
         """
         Handles clicks. Builds a list of coroutines and awaits on them in a gather call.
 
@@ -1614,6 +1693,11 @@ class PSSMScreen:
             x coordinate
         y : int
             y coordinate
+        action : TouchActionType
+            The type of interaction, which determines the action that is called on the element
+        element : Optional[elements.Element]
+            Dispatch the interaction to this element, instead of looking for the element at the coordinates.
+            Used for drags, which are captured by the element that was pressed down on, by default None
 
         Raises
         ------
@@ -1641,7 +1725,11 @@ class PSSMScreen:
             except (TypeError, KeyError, IndexError, OSError) as exce:
                 _LOGGER.error(f"adding on_interact function {self.on_interact} raised exception: {exce}")
             
-        if self.popupsOnTop:
+        if element is not None:
+            _LOGGER.verbose(f"Passing {action} to the element that captured it")
+            coro_list.extend(
+                await self._dispatch_click_to_element(touch_event, element))
+        elif self.popupsOnTop:
             _LOGGER.verbose("Passing click to the popup on top")
             popup = self.popupsOnTop[-1]
             if tools.coords_in_area(x, y, popup.area):
@@ -1710,6 +1798,9 @@ class PSSMScreen:
 
         elt_action = elt._get_action(action)
         show_elt_fb = Element.show_feedback.value(elt)
+        if action == "drag":
+            ##Feedback is not shown for drags, as an element would keep flashing for the entire duration of it
+            show_elt_fb = False
         if isinstance(elt,elements.Layout):
             if elt_action:
                 func, kwargs = elt_action

--- a/PythonScreenStackManager/pssm_types.py
+++ b/PythonScreenStackManager/pssm_types.py
@@ -68,7 +68,7 @@ class TouchEvent(NamedTuple):
     y: int
     "The y-coordinate of the touch"
 
-    touch_type: Literal[const.TOUCH_PRESS, const.TOUCH_RELEASE, const.TOUCH_TAP, const.TOUCH_LONG]
+    touch_type: Literal[const.TOUCH_PRESS, const.TOUCH_RELEASE, const.TOUCH_MOVE, const.TOUCH_TAP, const.TOUCH_LONG]
     "The type of touch"
 
 class InteractEvent(NamedTuple):
@@ -82,7 +82,7 @@ class InteractEvent(NamedTuple):
     "y coordinate of the interaction"
 
     action: str
-    "Type of interaction function that was registered. I.e. 'tap', 'hold' or 'hold_release'"
+    "Type of interaction function that was registered. I.e. 'tap', 'hold', 'hold_release' or 'drag'"
 
 class StyleStringDict(TypedDict):
     "Dict for styles. Mainly for backend purposes"
@@ -142,7 +142,7 @@ RotationValues = Literal["UR", "CW", "UD", "CCW"]
 textAlignmentType = tuple[TypeVar('horizontal'), TypeVar('vertical')]
 # "Text alignment type hint"
 
-TouchActionType = Literal["tap", "hold", "hold_release"]
+TouchActionType = Literal["tap", "hold", "hold_release", "drag"]
 
 class ScreenInit(TypedDict):
     "Type hint for the get_screen function, has all the arguments possible to initiate a screen instance."

--- a/tests_pssm/interaction_test.py
+++ b/tests_pssm/interaction_test.py
@@ -1,0 +1,358 @@
+##Tests for the way the screen handles interactions coming in from a device,
+##i.e. the dispatching of taps, holds and drags to the correct element.
+
+import asyncio
+
+from PythonScreenStackManager import constants as const
+from PythonScreenStackManager.constants import FEATURES
+from PythonScreenStackManager.devices import DeviceFeatures
+from PythonScreenStackManager.devices.dummy import DummyDevice
+from PythonScreenStackManager.elements import Button, Layout, Slider
+from PythonScreenStackManager.pssm import PSSMScreen
+from PythonScreenStackManager.pssm_types import TouchEvent
+
+DEBOUNCE_TIME = "10ms"
+HOLD_TIME = "400ms"
+
+##Time to wait in between putting events in the queue. Long enough to not debounce the touch, and short enough to not hold it.
+EVENT_INTERVAL = 0.05
+
+##Interval that is long enough for a touch to be considered held down
+HOLD_INTERVAL = 0.6
+
+##Time to wait for the dispatched actions to have been called
+DISPATCH_TIME = 0.1
+
+BUTTON_AREA = [(0,0),(100,100)]
+"Area of the test button, the interactions are dispatched within it"
+
+SLIDER_AREA = [(0,0),(100,200)]
+"Area of the test slider"
+
+OUTSIDE_BUTTON = (500,500)
+"Coordinates outside of the test button's area"
+
+
+def interactive_features(touch_move : bool = True) -> DeviceFeatures:
+    "Features of a device that reports presses and releases, and optionally the touch moving in between them"
+    features = [FEATURES.FEATURE_INTERACTIVE, FEATURES.FEATURE_PRESS_RELEASE]
+    if touch_move:
+        features.append(FEATURES.FEATURE_TOUCH_MOVE)
+    return DeviceFeatures(*features)
+
+
+class InteractiveDummyDevice(DummyDevice):
+    "Dummy device that can be interacted with"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._features = interactive_features()
+
+
+##The screen is a singleton, and setting up a new one leaves its event loop (and with it the shared generator pool) to be cleaned up.
+##So a single screen is set up for the entire module, and reset in between tests.
+device = InteractiveDummyDevice()
+screen = PSSMScreen(device, touch_debounce_time=DEBOUNCE_TIME, minimum_hold_time=HOLD_TIME)
+
+
+def make_screen(touch_move : bool = True) -> PSSMScreen:
+    "Returns the screen with an empty stack, and sets whether its device reports moving touches"
+    device._features = interactive_features(touch_move)
+    if screen.device is not device:
+        ##Another test module set up the screen singleton with its own device, so it is claimed back here
+        PSSMScreen(device, touch_debounce_time=DEBOUNCE_TIME, minimum_hold_time=HOLD_TIME)
+    screen.stack.clear()
+    return screen
+
+
+def make_button(screen : PSSMScreen, **kwargs) -> tuple[Button, list]:
+    """Puts a button on the stack that records the interactions dispatched to it.
+
+    Returns the button and the list its interactions are recorded in, as (action, x, y) tuples.
+    """
+    interactions = []
+
+    async def record(element, interaction, **kwargs):
+        ##Coroutines are awaited directly, functions would be put in the screen's thread pool
+        interactions.append((interaction.action, interaction.x, interaction.y))
+
+    actions = {"tap_action": record, "hold_action": record, "hold_release_action": record, "drag_action": record}
+    button = Button("test button", show_feedback=False, **(actions | kwargs))
+    button._area = BUTTON_AREA
+    screen.stack.append(button)
+    return button, interactions
+
+
+async def dispatch_events(screen : PSSMScreen, events : list, interval : float) -> None:
+    "Runs the touch handler and passes the events to it, as if they came from the device"
+
+    queue = asyncio.Queue()
+    async with screen._printLock:   ##The screen considers itself printing when this lock is held
+        handler = asyncio.create_task(screen._PSSMScreen__async_touch_handler(queue))
+        await asyncio.sleep(0)
+
+        for item in events:
+            event, wait = (item, interval) if isinstance(item, TouchEvent) else item
+            queue.put_nowait(event)
+            await asyncio.sleep(wait)
+
+        await asyncio.sleep(DISPATCH_TIME)
+        handler.cancel()
+
+
+def run_events(screen : PSSMScreen, *events, interval : float = EVENT_INTERVAL) -> None:
+    """Runs dispatch_events in the screen's event loop
+
+    Events are passed as ``TouchEvent`` instances, or as a tuple with the event and the time to wait after putting it in the queue.
+    """
+    asyncio.set_event_loop(screen.mainLoop)
+    screen.mainLoop.run_until_complete(dispatch_events(screen, events, interval))
+
+
+class TestInteractionHandling:
+
+    def test_tap(self):
+        "A press and a release without moving calls the tap_action"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(10,10, const.TOUCH_RELEASE))
+
+        assert interactions == [("tap", 10, 10)]
+
+    def test_hold(self):
+        "Not releasing before the hold time elapsed calls the hold_action, and the hold_release_action on release"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(20,20, const.TOUCH_RELEASE),
+                interval=HOLD_INTERVAL)
+
+        assert interactions == [("hold", 10, 10), ("hold_release", 20, 20)]
+
+    def test_debounce(self):
+        "Releasing before the debounce time elapsed does not dispatch anything"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        async def bounce():
+            queue = asyncio.Queue()
+            async with screen._printLock:
+                handler = asyncio.create_task(screen._PSSMScreen__async_touch_handler(queue))
+                await asyncio.sleep(0)
+                queue.put_nowait(TouchEvent(10,10, const.TOUCH_PRESS))
+                queue.put_nowait(TouchEvent(10,10, const.TOUCH_RELEASE))
+                await asyncio.sleep(DISPATCH_TIME)
+                handler.cancel()
+
+        asyncio.set_event_loop(screen.mainLoop)
+        screen.mainLoop.run_until_complete(bounce())
+
+        assert interactions == []
+
+    def test_drag(self):
+        "Moving the touch calls the drag_action, and a final one when the touch is released"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(20,20, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_RELEASE))
+
+        assert interactions == [("drag", 20, 20), ("drag", 30, 30), ("drag", 30, 30)]
+
+    def test_drag_captures_touch(self):
+        "The element that was pressed down on keeps getting the drag events when the touch leaves its area"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(*OUTSIDE_BUTTON, const.TOUCH_MOVE),
+                TouchEvent(*OUTSIDE_BUTTON, const.TOUCH_RELEASE))
+
+        assert interactions == [("drag", *OUTSIDE_BUTTON), ("drag", *OUTSIDE_BUTTON)]
+
+    def test_drag_suppresses_hold(self):
+        "A touch that is being dragged does not turn into a hold"
+
+        screen = make_screen()
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                (TouchEvent(20,20, const.TOUCH_MOVE), HOLD_INTERVAL),    ##The touch starts moving before the hold time elapses, and is then held down for far longer than it
+                TouchEvent(30,30, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_RELEASE))
+
+        assert ("hold", 10, 10) not in interactions
+        assert interactions == [("drag", 20, 20), ("drag", 30, 30), ("drag", 30, 30)]
+
+    def test_no_drag_without_action(self):
+        "An element without a drag action is not dragged, and gets a tap instead"
+
+        screen = make_screen()
+        _, interactions = make_button(screen, drag_action=None)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(20,20, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_RELEASE))
+
+        assert interactions == [("tap", 30, 30)]
+
+    def test_no_drag_without_feature(self):
+        "Devices without the touch move feature do not dispatch drags"
+
+        screen = make_screen(touch_move=False)
+        _, interactions = make_button(screen)
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(20,20, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_RELEASE))
+
+        assert interactions == [("tap", 30, 30)]
+
+    def test_drag_as_tap(self):
+        "Elements with drag_as_tap set call their tap_action when they are dragged"
+
+        screen = make_screen()
+        button, interactions = make_button(screen, drag_action=None, drag_as_tap=True)
+
+        called = []
+
+        async def record_tap(element, interaction, **kwargs):
+            called.append(interaction.action)
+
+        button.tap_action = record_tap
+
+        run_events(screen,
+                TouchEvent(10,10, const.TOUCH_PRESS),
+                TouchEvent(20,20, const.TOUCH_MOVE),
+                TouchEvent(30,30, const.TOUCH_RELEASE))
+
+        ##The interactions are still passed on as drags, they are just handled by the tap_action
+        assert called == ["drag", "drag"]
+        assert interactions == []
+
+
+class TestSliderDragging:
+
+    def make_slider(self, screen : PSSMScreen, **kwargs) -> tuple[Slider, list]:
+        "Puts a generated slider on the stack, and returns it with the list its positions are recorded in"
+        positions = []
+
+        async def record_position(element, position, **kwargs):
+            positions.append(position)
+
+        slider = Slider(orientation="horizontal", minimum=0, maximum=100, position=0,
+                        on_position_set=record_position, **kwargs)
+        slider._area = SLIDER_AREA
+        slider.generate(area=SLIDER_AREA)   ##Generating sets the coordinates of the line, which are needed to determine the position of a touch
+        screen.stack.append(slider)
+        return slider, positions
+
+    def test_slider_drag(self):
+        "Dragging an interactive slider updates its position while the touch is moving"
+
+        screen = make_screen()
+        slider, positions = self.make_slider(screen)
+
+        assert screen._get_drag_element(20,50) == slider
+
+        run_events(screen,
+                TouchEvent(20,50, const.TOUCH_PRESS),
+                TouchEvent(50,50, const.TOUCH_MOVE),
+                TouchEvent(90,50, const.TOUCH_MOVE),
+                TouchEvent(90,50, const.TOUCH_RELEASE))
+
+        assert len(positions) > 1, "The slider should have been updated while the touch was moving"
+        assert positions == sorted(positions), "The slider should have followed the touch to the right"
+        assert slider.position == slider.maximum
+
+    def test_slider_tap(self):
+        "Tapping a slider still sets its position, without dragging it"
+
+        screen = make_screen()
+        slider, positions = self.make_slider(screen)
+
+        run_events(screen,
+                TouchEvent(20,50, const.TOUCH_PRESS),
+                TouchEvent(20,50, const.TOUCH_RELEASE))
+
+        assert len(positions) == 1
+        assert slider.position == positions[0]
+
+    def test_non_interactive_slider(self):
+        "Sliders that are not interactive do not capture the touch"
+
+        screen = make_screen()
+        slider, positions = self.make_slider(screen, interactive=False)
+
+        assert screen._get_drag_element(20,50) is None
+
+        run_events(screen,
+                TouchEvent(20,50, const.TOUCH_PRESS),
+                TouchEvent(50,50, const.TOUCH_MOVE),
+                TouchEvent(90,50, const.TOUCH_RELEASE))
+
+        assert positions == []
+        assert slider.position == 0
+
+
+class TestDragTargets:
+
+    def test_element_drag_target(self):
+        "Elements only capture a touch if they have an action for drags"
+
+        screen = make_screen()
+        button, _ = make_button(screen)
+
+        assert button._get_drag_target(10,10) == button
+        assert screen._get_drag_element(10,10) == button
+        assert screen._get_drag_element(*OUTSIDE_BUTTON) is None
+
+        button.drag_action = None
+        assert button._get_drag_target(10,10) is None
+        assert screen._get_drag_element(10,10) is None
+
+        button.drag_as_tap = True
+        assert button._get_drag_target(10,10) == button, "drag_as_tap should make the element capture the touch"
+
+    def test_layout_drag_target(self):
+        "Layouts pass on the capturing of a touch to the element that is at those coordinates"
+
+        screen = make_screen()
+        button, _ = make_button(screen)
+        screen.stack.clear()
+
+        empty_button = Button("no dragging here", show_feedback=False)
+        layout = Layout([["?", (empty_button, "?")], ["?", (button, "?")]])
+        layout._area = [(0,0),(200,200)]
+        layout.generate(area=layout._area)
+        screen.stack.append(layout)
+
+        button_x = button.area[0][0] + 1
+        button_y = button.area[0][1] + 1
+
+        assert layout._get_element_at(button_x, button_y) == button
+        assert layout._get_drag_target(button_x, button_y) == button
+        assert screen._get_drag_element(button_x, button_y) == button
+
+        empty_x = empty_button.area[0][0] + 1
+        empty_y = empty_button.area[0][1] + 1
+
+        assert layout._get_drag_target(empty_x, empty_y) is None
+        assert screen._get_drag_element(empty_x, empty_y) is None


### PR DESCRIPTION
Implements #3, against `dev` as you asked. No rush at all — take the time you need, and congratulations on nearly being through the master's.

Following your answers, this turned out quite different from the sketch in the issue, so here is what it ended up being.

### A dedicated `drag` action

Elements get a `drag_action`, alongside `tap_action`/`hold_action`/`hold_release_action` and working exactly like them (`drag_action_data`, `drag_action_map`, shorthands, dicts). The interaction is passed as an `InteractEvent` with `action = "drag"`.

For "have drag and tap do the same thing", elements take a `drag_as_tap` boolean:

```yaml
- type: Button
  tap_action: my_function
  drag_as_tap: true
```

`_get_action("drag")` then falls back to the tap action when no `drag_action` is set. The event itself is still passed as a drag, so a function can still tell the two apart if it wants to.

### A new device feature

`FEATURE_TOUCH_MOVE`, for devices that report the touch moving in between a press and a release (so it implies `FEATURE_PRESS_RELEASE`). Those devices put `TOUCH_MOVE` events in the touch queue. Without the feature nothing changes: move events are never expected, and the handler behaves exactly as before.

`devices/windowed.py` declares it and binds `<B1-Motion>`, so dragging can be tested with a mouse in the emulator. Tkinter reports a motion event per pixel, so it only passes one on every 5 px.

### About the `draggable` opt-in

That question of mine was badly phrased, sorry — I meant an element-level opt-in, since motion has to be routed to *something*. It is no longer a separate property: an element captures a touch if it has an action for drags at all (`drag_action`, or `tap_action` with `drag_as_tap`), so there is nothing extra to set.

The capturing itself is `Element._get_drag_target(x, y)`, which `Layout` overrides to pass the request on to the element at those coordinates (via a new `Layout._get_element_at`). The screen resolves the target once, when the touch is pressed down, and that element then receives every drag event until the release — also when the touch moves outside of its area, which is what makes a slider usable near the ends. Popups are handled the same way as in `_async_interact_handler`.

### Behaviour decisions worth a look

- **Moving cancels the hold.** Once a touch starts dragging, no `hold_action` is dispatched for it. If it was already held down long enough before it moved, the `hold_release_action` still fires on release.
- **A drag replaces the tap.** On release, a touch that was dragged gets a final drag event on the release coordinates instead of a `tap_action`. A press and release without any movement is still a plain tap, so tapping a slider behaves exactly as it does now.
- **No feedback on drags.** `show_feedback` is skipped for drag events, since the element would keep flashing for the whole drag.
- **The debounce is now only about the release.** It used to discard the interaction if *any* event arrived within the debounce time, which would eat the first move of a drag. It now only debounces a release that comes in that quickly.
- `_async_interact_handler` grew an optional `element` argument, to dispatch to the element that captured the touch instead of looking one up at the coordinates.

`_BaseSlider` implements `drag_action` the same way it does `tap_action`: it sets the position and then calls the user's function, and only captures the touch when it is `interactive`.

### Testing

`tests_pssm/interaction_test.py` runs the touch handler with a dummy interactive device and asserts what the elements on the stack get: taps, holds, the debounce, drags (including capture and hold suppression), the no-feature and no-action paths, and dragging an actual `Slider`. No new test dependencies.

The mechanism is also in daily use here: I backported the same handler onto 0.4.0 for a Kobo Libra 2 dashboard, where the frontlight slider now follows a finger. The device side of that (a Kobo platform that emits move events) is the separate `inkBoard` contribution I mentioned in the issue, which I would like to offer once you are happy with this part.
